### PR TITLE
OA-19 - upgraded Jackson version to the current release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.1.4.RELEASE</spring.version>
         <spring.security.version>4.0.4.RELEASE</spring.security.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
I update the dependencies with the newer versions which is 2.9.8
## Issue I worked on

https://issues.openmrs.org/browse/OA-19